### PR TITLE
US 3, merchant bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -22,4 +22,12 @@ class BulkDiscountsController < ApplicationController
 
     redirect_to bulk_discounts_path
   end
+
+  def destroy
+    bulk_discount = BulkDiscount.find(params[:id])
+
+    bulk_discount.destroy if bulk_discount
+    
+    redirect_to bulk_discounts_path
+  end
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,5 +6,6 @@
     <p>Percentage Off: <%= discount.percentage_off %></p>
     <p>Quantity Threshold: <%= discount.threshold %></p>
     <p><%= link_to "Bulk ID-#{discount.id} Show Page", bulk_discount_path(discount.id)%></p>
+    <p><%= link_to "Remove Discount ID##{discount.id}", bulk_discount_path(discount.id), method: :delete %></p>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,5 @@ Rails.application.routes.draw do
   end
 
   # Bulk Discounts
-  resources :bulk_discounts, only: [:index, :show, :new, :create]
+  resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -38,4 +38,17 @@ RSpec.describe "BulkDiscount Index", type: :feature do
 
     expect(current_path).to eq(new_bulk_discount_path)
   end
+
+  #Bulk US-3
+  it "displays a button to delete the discount" do
+    visit bulk_discounts_path
+
+    within("#bulk-#{@bulk1.id}") do
+      expect(page).to have_link("Remove Discount ID##{@bulk1.id}")
+      click_link("Remove Discount ID##{@bulk1.id}")
+      expect(current_path).to eq(bulk_discounts_path)
+    end
+
+    expect(page).to_not have_link("Remove Discount ID##{@bulk1.id}")
+  end
 end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete
As a merchant:

When I visit my bulk discounts index
Then next to each bulk discount I see a button to delete it
When I click this button
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed