### PR TITLE
US 5, merchant bulk discount edit and update

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -13,14 +13,16 @@ class BulkDiscountsController < ApplicationController
   end
 
   def create
-    merchant = Merchant.find(params[:merchant_id])
+    merchant = Merchant.find(bulk_discount_params[:merchant_id])
 
-    merchant.bulk_discounts.create!({
-      percentage_off: params[:percentage_off],
-      threshold: params[:threshold]
-    })
+    bulk_discount = merchant.bulk_discounts.build(bulk_discount_params)
 
-    redirect_to bulk_discounts_path
+    if bulk_discount.save
+      redirect_to bulk_discounts_path, notice: "Discount created successfully"
+    else
+      flash[:alert] = "Error: #{error_message(bulk_discount.errors)}"
+      render :new
+    end
   end
 
   def destroy
@@ -29,5 +31,26 @@ class BulkDiscountsController < ApplicationController
     bulk_discount.destroy if bulk_discount
     
     redirect_to bulk_discounts_path
+  end
+
+  def edit
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
+
+  def update
+    bulk_discount = BulkDiscount.find(params[:id])
+
+    if bulk_discount.update(bulk_discount_params)
+      redirect_to bulk_discounts_path, notice: "Discount successfully updated"
+    else
+      flash[:alert] = "Error: #{error_message(bulk_discount.errors)}"
+      render :edit
+    end
+  end
+
+  private
+  
+  def bulk_discount_params
+    params.require(:bulk_discount).permit(:percentage_off, :threshold, :merchant_id)
   end
 end

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>Edit a Discount</h1>
+<%= form_with model: @bulk_discount, method: :patch, data: { turbo: false } do |form| %>
+  <%= form.label :percentage_off %>
+  <%= form.number_field :percentage_off %>
+
+  <%= form.label :threshold %>
+  <%= form.number_field :threshold %>
+  <%= form.submit "Update Discount" %>
+<% end %>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,5 +1,5 @@
 <h1>Add a New Discount</h1>
-<%= form_with url: bulk_discounts_path, method: :post, data: { turbo: false } do |form| %>
+<%= form_with model: @bulk_discount, url: bulk_discounts_path, method: :post, data: { turbo: false } do |form| %>
   <%= form.label :merchant_id, 'Select Merchant' %>
   <%= form.collection_select :merchant_id, @merchants, :id, :name, prompt: 'Choose a Merchant' %>
 

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,4 +1,5 @@
 <h1><%= @bulk_discount.merchant.name %>: Bulk Discount ID#<%= @bulk_discount.id %> Show Page</h1>
 <br>
+<p><%= link_to "Edit Discount", edit_bulk_discount_path(@bulk_discount) %></p>
 <p><strong>Percentage Off: </strong><%= @bulk_discount.percentage_off %></p>
 <p><strong>Quantity Threshold: </strong><%= @bulk_discount.threshold %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,5 @@ Rails.application.routes.draw do
   end
 
   # Bulk Discounts
-  resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+  resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe BulkDiscount, type: :feature do
+  before :each do
+    @merchant1 = create(:merchant)
+
+    @bulk1 = create(:bulk_discount, percentage_off: 15, threshold: 5, merchant: @merchant1)
+  end
+  
+  #Bulk US-5
+  it "displays a form to edit bulk discount" do
+    visit edit_bulk_discount_path(@bulk1)
+
+    fill_in 'Percentage off', with: 30
+    fill_in 'Threshold', with: 10
+    click_button "Update Discount"
+
+    expect(current_path).to eq(bulk_discounts_path)
+    expect(page).to have_content("Percentage Off: 30")
+    expect(page).to have_content("Quantity Threshold: 10")
+  end
+end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "BulkDiscount Index", type: :feature do
   end
 
   #Bulk US-1
-  xit "displays all bulk discounts including their attributes and a redirect link to the show page" do
+  it "displays all bulk discounts including their attributes and a redirect link to the show page" do
     visit bulk_discounts_path
 
     [@bulk1, @bulk2, @bulk3, @bulk4].each do |bulk|

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "BulkDiscount Index", type: :feature do
     expect(page).to have_content("Add a New Discount")
 
     select(@merchant1.name, from: 'Merchant')
-    fill_in :percentage_off, with: 10
-    fill_in :threshold, with: 5
+    fill_in 'Percentage off', with: 10
+    fill_in 'Threshold', with: 5
 
     click_on 'Create New Discount'
 

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe "Bulk Discounts Show Page" do
     expect(page).to have_content("Percentage Off: #{@bulk1.percentage_off}")
     expect(page).to have_content("Quantity Threshold: #{@bulk1.threshold}")
   end
+
+  #Bulk US-5
+  it "displays a link to edit the discount" do
+    visit bulk_discount_path(@bulk1)
+
+    expect(page).to have_link("Edit Discount")
+    click_link("Edit Discount")
+    expect(current_path).to eq(edit_bulk_discount_path(@bulk1))
+  end
 end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit
As a merchant:

When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discount's current attributes are pre-populated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated



Flash alerts and notices have been included along with permit params