### PR TITLE
US 7, merchant invoice show page: link to applied discounts

### DIFF
--- a/app/controllers/merchants/invoices_controller.rb
+++ b/app/controllers/merchants/invoices_controller.rb
@@ -6,8 +6,8 @@ class Merchants::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
     @merchant = Merchant.find(params[:merchant_id])
-    # require'pry';binding.pry
   end
+  
   def update
     @item = Item.find(params[:item_id])
     

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -17,9 +17,11 @@ class Invoice < ApplicationRecord
   end
 
   def total_revenue_after_discounts
-    self.total_revenue - self.invoice_items.joins(item: {merchant: :bulk_discounts})
-    .where("invoice_items.quantity >= bulk_discounts.threshold")
-    .select('invoice_items.*', 'bulk_discounts.percentage_off', 'bulk_discounts.threshold')
-    .sum("invoice_items.quantity * (invoice_items.unit_price * bulk_discounts.percentage_off/100.0)") 
+    # require 'pry';binding.pry
+    self.total_revenue - invoice_items.joins(item: { merchant: :bulk_discounts })
+    .where('invoice_items.quantity >= bulk_discounts.threshold')
+    .group('invoice_items.id')
+    .pluck(Arel.sql('MAX(bulk_discounts.percentage_off) * invoice_items.unit_price * (invoice_items.quantity / 100.0)'))
+    .sum
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -12,4 +12,11 @@ class InvoiceItem < ApplicationRecord
     .select('id', 'invoices.id as invoice_id', 'invoice_items.status', 'invoices.created_at')
     .order('invoices.created_at ASC')
   end
+
+  def applicable_discount
+    item.merchant.bulk_discounts
+        .where("bulk_discounts.threshold <= ?", quantity)
+        .order(percentage_off: :desc)
+        .first
+  end
 end

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -4,31 +4,34 @@
 <p>Status: <%= @invoice.status %></p>
 <p>Date Created: <%= @invoice.date_format %></p>
 <p>Total revenue: <%= number_to_currency(@invoice.total_revenue) %></p>
-<p>Total Revenue after Discounts: <%= number_to_currency(@invoice.total_revenue_after_discounts) %></p>
+<p>Total Revenue after Discounts(if applicable): <%= number_to_currency(@invoice.total_revenue_after_discounts) %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 <section id="item_status">
-<p>Items on the invoice: <% @merchant.merchant_items(@merchant.id).each do |item|%></p>
-  <p>Name: <%= item.name %></p>
-  <p>Quantity sold: <%= item.quantity %></p>
-  <p>Price sold: <%= number_to_currency(item.price_total) %>
+<p>Items on the invoice: <% @invoice.invoice_items.each do |invoice_item|%></p>
+  <% if invoice_item.applicable_discount != nil %>
+  <%= link_to "Discount Show Page", bulk_discount_path(invoice_item.applicable_discount) %></p>
+  <% end %>
+  <p>Name: <%= invoice_item.item.name %></p>
+  <p>Quantity sold: <%= invoice_item.quantity %></p>
+  <p>Price sold: <%= number_to_currency(invoice_item.item.price_total) %>
   <p>Status Form:  <%= form_with(url: "/merchants/#{@merchant.id}/invoices/#{@invoice.id}", method: :patch, local: true) do |form| %>
-                 <% if item.status == "disabled" %>
+                 <% if invoice_item.item.status == "disabled" %>
                   <%= form.select :status, ["Enabled", "Disabled"], selected: "Disabled"%>
-                 <% elsif item.status == "enabled"%>
+                 <% elsif invoice_item.item.status == "enabled"%>
                   <%= form.select :status, ["Enabled", "Disabled"], selected: "Enabled"%>
                  <% end %>
-              <%= form.hidden_field :item_id, value: item.id%>
+              <%= form.hidden_field :item_id, value: invoice_item.item.id%>
               <%= form.submit "Update Item Status"%>
               <% end %>
 </section>
-  <p>Status: <% if item.shipping_status == 2 %>
-                Shipped</P>
-              <% elsif item.shipping_status == 1%>
-                Packaged</p>
-                <% else %>
-                Pending</p>
-             <% end %>
-  <br>
+  <%# <p>Status: <% if item.shipping_status == 2 %>
+                <%# Shipped</P> %>
+              <%# <% elsif item.shipping_status == 1%> 
+                <%# Packaged</p> %>
+                <%# <% else %> 
+                <%# Pending</p> %>
+             <%# <% end %> 
+  <%# <br>  %>
 <%end%>
 
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -42,45 +42,62 @@ RSpec.describe "merchant invoice show page" do
   # end
 
   before :each do
+    # @merchant1 = create(:merchant, enabled: true)
+    # @merchant2 = create(:merchant, enabled: true)
+    # @merchant3 = create(:merchant, enabled: true)
+    # @merchant4 = create(:merchant)
+    # @merchant5 = create(:merchant)
+
+    # @customer1 = create(:customer)
+    # @customer2 = create(:customer)
+    # @customer3 = create(:customer)
+    # @customer4 = create(:customer)
+    # @customer5 = create(:customer)
+
+    # @invoice1 = create(:invoice, customer: @customer1, created_at: "2023-11-07 00:04:06.477179000 +0000")
+    # @invoice2 = create(:invoice, customer: @customer2, created_at: "2020-10-02 00:04:06.477179000 +0000")
+    # @invoice3 = create(:invoice, customer: @customer3)
+    # @invoice4 = create(:invoice, customer: @customer4)
+    # @invoice5 = create(:invoice, customer: @customer5)
+
+    # @item1 = create(:item, merchant: @merchant1)
+    # @item2 = create(:item, merchant: @merchant2)
+    # @item3 = create(:item, merchant: @merchant3)
+    # @item4 = create(:item, merchant: @merchant4)
+    # @item5 = create(:item, merchant: @merchant5)
+
+    # # Create invoice items with unit prices and quantities associated with invoices
+    # @invoice_item1 = create(:invoice_item, item: @item1, invoice: @invoice1, unit_price: 10, quantity: 5)
+    # @invoice_item2 = create(:invoice_item, item: @item2, invoice: @invoice2, unit_price: 15, quantity: 3)
+    # @invoice_item3 = create(:invoice_item, item: @item3, invoice: @invoice3, unit_price: 8, quantity: 5)
+    # @invoice_item4 = create(:invoice_item, item: @item4, invoice: @invoice4, unit_price: 9, quantity: 4)
+    # @invoice_item5 = create(:invoice_item, item: @item5, invoice: @invoice5, unit_price: 9, quantity: 2)
+
+    # # Create successful transactions for invoices
+    # @transaction1 = create(:transaction, invoice: @invoice1, result: 0) # Successful
+    # @transaction2 = create(:transaction, invoice: @invoice2, result: 0) # Successful
+    # @transaction3 = create(:transaction, invoice: @invoice3, result: 0) # Successful
+    # @transaction4 = create(:transaction, invoice: @invoice4, result: 0) # Successful
+    # @transaction5 = create(:transaction, invoice: @invoice5, result: 0) # Successful
+
+    # @bulk1 = create(:bulk_discount, percentage_off: 10, threshold: 5, merchant: @merchant1)
+
     @merchant1 = create(:merchant, enabled: true)
-    @merchant2 = create(:merchant, enabled: true)
-    @merchant3 = create(:merchant, enabled: true)
-    @merchant4 = create(:merchant)
-    @merchant5 = create(:merchant)
-
-    @customer1 = create(:customer)
-    @customer2 = create(:customer)
-    @customer3 = create(:customer)
-    @customer4 = create(:customer)
-    @customer5 = create(:customer)
-
-    @invoice1 = create(:invoice, customer: @customer1, created_at: "2023-11-07 00:04:06.477179000 +0000")
-    @invoice2 = create(:invoice, customer: @customer2, created_at: "2020-10-02 00:04:06.477179000 +0000")
-    @invoice3 = create(:invoice, customer: @customer3)
-    @invoice4 = create(:invoice, customer: @customer4)
-    @invoice5 = create(:invoice, customer: @customer5)
 
     @item1 = create(:item, merchant: @merchant1)
-    @item2 = create(:item, merchant: @merchant2)
-    @item3 = create(:item, merchant: @merchant3)
-    @item4 = create(:item, merchant: @merchant4)
-    @item5 = create(:item, merchant: @merchant5)
+    @item2 = create(:item, merchant: @merchant1)
+    @item3 = create(:item, merchant: @merchant1)
 
-    # Create invoice items with unit prices and quantities associated with invoices
+    @customer1 = create(:customer)
+
+    @invoice1 = create(:invoice, customer: @customer1)
+
     @invoice_item1 = create(:invoice_item, item: @item1, invoice: @invoice1, unit_price: 10, quantity: 5)
-    @invoice_item2 = create(:invoice_item, item: @item2, invoice: @invoice2, unit_price: 15, quantity: 3)
-    @invoice_item3 = create(:invoice_item, item: @item3, invoice: @invoice3, unit_price: 8, quantity: 5)
-    @invoice_item4 = create(:invoice_item, item: @item4, invoice: @invoice4, unit_price: 9, quantity: 4)
-    @invoice_item5 = create(:invoice_item, item: @item5, invoice: @invoice5, unit_price: 9, quantity: 2)
-
-    # Create successful transactions for invoices
-    @transaction1 = create(:transaction, invoice: @invoice1, result: 0) # Successful
-    @transaction2 = create(:transaction, invoice: @invoice2, result: 0) # Successful
-    @transaction3 = create(:transaction, invoice: @invoice3, result: 0) # Successful
-    @transaction4 = create(:transaction, invoice: @invoice4, result: 0) # Successful
-    @transaction5 = create(:transaction, invoice: @invoice5, result: 0) # Successful
+    @invoice_item1 = create(:invoice_item, item: @item2, invoice: @invoice1, unit_price: 5, quantity: 1)
+    @invoice_item1 = create(:invoice_item, item: @item3, invoice: @invoice1, unit_price: 15, quantity: 10)
 
     @bulk1 = create(:bulk_discount, percentage_off: 10, threshold: 5, merchant: @merchant1)
+    @bulk2 = create(:bulk_discount, percentage_off: 20, threshold: 10, merchant: @merchant1)
   end
 
   #US 15
@@ -128,20 +145,32 @@ RSpec.describe "merchant invoice show page" do
       expect(current_path).to eq("/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}")
     end
   end
-
   
   #Bulk US-6
   describe "Merchant Invoice Show Page: Total and Discounted Revenue" do
     it "displays total revenue for merchant from the invoice before discounts" do
       visit merchant_invoice_path(@merchant1, @invoice1) 
 
-      expect(page).to have_content("Total revenue: $50.00")
+      expect(page).to have_content("Total revenue: $205.00")
     end
 
     it "displays the discounted revenue from the merchant invoice with the bulk discounts included" do
       visit merchant_invoice_path(@merchant1, @invoice1) 
 
-      expect(page).to have_content("Total Revenue after Discounts: $45.00")
+      expect(page).to have_content("Total Revenue after Discounts(if applicable): $170.00")
+    end
+  end
+
+  #Bulk US-7
+  describe "Merchant Invoice Show Page: Link to Applied Discounts" do
+    it "displays a link to the bulk discount show page if a discount was applied" do
+      visit merchant_invoice_path(@merchant1, @invoice1)
+
+      within("#item_status") do
+        expect(page).to have_link("Discount Show Page")
+        click_link("Discount Show Page")
+        expect(current_path).to eq(bulk_discount_path(@bulk1))
+      end
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -38,14 +38,24 @@ RSpec.describe Invoice, type: :model do
     describe "#total_revenue_after_discounts" do
       it "can find the total revenue after applicable discounts" do
         @merchant1 = create(:merchant, enabled: true)
-        @customer1 = create(:customer)
-        @invoice1 = create(:invoice, customer: @customer1)
-        @item1 = create(:item, merchant: @merchant1)
-        @invoice_item1 = create(:invoice_item, item: @item1, invoice: @invoice1, unit_price: 10, quantity: 5)
-        @bulk1 = create(:bulk_discount, percentage_off: 10, threshold: 5, merchant: @merchant1)
 
-        expect(@invoice1.total_revenue).to eq(50)
-        expect(@invoice1.total_revenue_after_discounts).to eq(45)
+        @item1 = create(:item, merchant: @merchant1)
+        @item2 = create(:item, merchant: @merchant1)
+        @item3 = create(:item, merchant: @merchant1)
+
+        @customer1 = create(:customer)
+
+        @invoice1 = create(:invoice, customer: @customer1)
+
+        @invoice_item1 = create(:invoice_item, item: @item1, invoice: @invoice1, unit_price: 10, quantity: 5)
+        @invoice_item1 = create(:invoice_item, item: @item2, invoice: @invoice1, unit_price: 5, quantity: 1)
+        @invoice_item1 = create(:invoice_item, item: @item3, invoice: @invoice1, unit_price: 15, quantity: 10)
+
+        @bulk1 = create(:bulk_discount, percentage_off: 10, threshold: 5, merchant: @merchant1)
+        @bulk2 = create(:bulk_discount, percentage_off: 20, threshold: 10, merchant: @merchant1)
+
+        expect(@invoice1.total_revenue).to eq(205)
+        expect(@invoice1.total_revenue_after_discounts).to eq(170)
       end
     end
   end


### PR DESCRIPTION
7: Merchant Invoice Show Page: Link to applied discounts
As a merchant:

When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)

Working in another section, I had to edit the show page to display and iterate in a manner that I was able to link a redirect for applicable discounts. 